### PR TITLE
fix(security): harden avatar paths, report updates, and invite accept

### DIFF
--- a/Changelog/v1.2.0.md
+++ b/Changelog/v1.2.0.md
@@ -27,6 +27,12 @@
 - Report export permalinks now use `/admin/reports/<id>`, matching email/notification links and the real Admin Console route (previously `/reports/<id>` omitted the `/admin` basename).
 - Reports list pagination no longer resets to page 1 when using Next/Previous.
 
+### Security
+
+- Avatar serving is now confined to the requesting user's own directory. Path traversal in the `GET /api/users/me/avatar/:filename` route is rejected (encoded `..`, path separators, and NUL bytes), so a crafted filename can no longer read files outside the avatars directory.
+- Report updates (`PATCH /api/reports/:id`) now use the validated request body instead of the raw payload, dropping the `forwardedTo` field. This closes a mass-assignment gap where clients could inject forwarded-integration references directly.
+- Invitation acceptance consumes its token atomically. Concurrent accepts for the same token can no longer both succeed, preventing duplicate account activation or token reuse.
+
 ### Maintenance
 
 - Added `xlsx` for Excel share downloads; downloads use a shared blob helper that revokes object URLs after download.

--- a/src/server/database/repositories/users.repo.ts
+++ b/src/server/database/repositories/users.repo.ts
@@ -314,9 +314,15 @@ export const usersRepo = {
   },
 
   /**
-   * Accept invitation: set password, clear token, mark as active
+   * Accept invitation: set password, clear token, mark as active.
+   * Consumes the token atomically so concurrent accepts cannot both succeed.
    */
-  async acceptInvitation(id: string, passwordHash: string, name?: string): Promise<User | null> {
+  async acceptInvitation(
+    id: string,
+    token: string,
+    passwordHash: string,
+    name?: string
+  ): Promise<User | null> {
     const db = getDb();
     const now = new Date().toISOString();
 
@@ -335,9 +341,19 @@ export const usersRepo = {
       params.push(name);
     }
 
-    params.push(id);
+    params.push(id, token);
 
-    db.run(`UPDATE users SET ${sets.join(', ')} WHERE id = ?`, params);
+    const result = db.run(
+      `UPDATE users SET ${sets.join(', ')}
+       WHERE id = ?
+         AND invitation_token = ?
+         AND invitation_accepted_at IS NULL`,
+      params
+    );
+
+    if (result.changes === 0) {
+      return null;
+    }
 
     return this.findById(id);
   },

--- a/src/server/routes/api/reports.ts
+++ b/src/server/routes/api/reports.ts
@@ -196,7 +196,13 @@ reports.patch(
   async (c) => {
     const id = c.req.param('id');
     const user = c.get('user');
-    const body = await c.req.json();
+    const body = c.get('validatedBody' as never) as {
+      title?: string;
+      description?: string;
+      status?: 'open' | 'in_progress' | 'resolved' | 'closed';
+      priority?: 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+      assignedTo?: string | null;
+    };
 
     const result = await reportsService.update(id, body, user.id);
 

--- a/src/server/routes/api/users.ts
+++ b/src/server/routes/api/users.ts
@@ -6,8 +6,8 @@ import { validate, schemas } from '../../middleware/validate.js';
 import { saveAvatar, deleteAllAvatars } from '../../storage/files.js';
 import { config } from '../../config.js';
 import { settingsCacheService } from '../../services/settings-cache.service.js';
+import { resolvePathInside } from '../../utils/safe-path.js';
 import type { User } from '@shared/types';
-import * as path from 'path';
 
 const users = new Hono();
 
@@ -270,7 +270,10 @@ users.get('/me/avatar/:filename', authMiddleware, async (c) => {
   const currentUser = c.get('user') as User;
   const filename = c.req.param('filename');
 
-  const filePath = path.join(config.avatarsDir, currentUser.id, filename);
+  const filePath = resolvePathInside(config.avatarsDir, currentUser.id, filename);
+  if (!filePath) {
+    return c.json({ success: false, error: 'NOT_FOUND', message: 'Avatar not found' }, 404);
+  }
 
   try {
     const file = Bun.file(filePath);

--- a/src/server/services/invitations.service.ts
+++ b/src/server/services/invitations.service.ts
@@ -245,15 +245,16 @@ export const invitationsService = {
     // Hash password
     const passwordHash = await hashPassword(input.password);
 
-    // Accept invitation
+    // Accept invitation (token must still be unconsumed — loses the race otherwise)
     const user = await usersRepo.acceptInvitation(
       userWithToken.id,
+      input.token,
       passwordHash,
       input.name.trim()
     );
 
     if (!user) {
-      return Result.fail('Failed to accept invitation', 'ACCEPT_FAILED');
+      return Result.fail('Invitation has already been accepted', 'ALREADY_ACCEPTED');
     }
 
     // Create session for auto-login

--- a/src/server/services/reports.service.ts
+++ b/src/server/services/reports.service.ts
@@ -23,7 +23,6 @@ import type {
   PaginatedResponse,
   FileType,
   FileRecord,
-  ForwardedReference,
   LocaleCode,
 } from '@shared/types';
 
@@ -68,7 +67,6 @@ export interface UpdateReportInput {
   priority?: ReportPriority;
   assignedTo?: string | null;
   resolvedBy?: string;
-  forwardedTo?: ForwardedReference[];
 }
 
 async function validateAssignee(assignedTo: string | null | undefined): Promise<Result<void>> {
@@ -540,10 +538,6 @@ export const reportsService = {
       }
 
       updates.assignedTo = input.assignedTo ?? undefined;
-    }
-
-    if (input.forwardedTo !== undefined) {
-      updates.forwardedTo = input.forwardedTo;
     }
 
     const report = await reportsRepo.update(id, updates);

--- a/src/server/utils/safe-path.ts
+++ b/src/server/utils/safe-path.ts
@@ -1,0 +1,31 @@
+import * as path from 'path';
+
+/**
+ * Resolve a path under `baseDir`, rejecting traversal / separator abuse.
+ * Returns null when any segment is unsafe or the result escapes `baseDir`.
+ */
+export function resolvePathInside(baseDir: string, ...parts: string[]): string | null {
+  for (const part of parts) {
+    if (
+      typeof part !== 'string' ||
+      part.length === 0 ||
+      part === '.' ||
+      part === '..' ||
+      part.includes('/') ||
+      part.includes('\\') ||
+      part.includes('\0')
+    ) {
+      return null;
+    }
+  }
+
+  const resolvedBase = path.resolve(baseDir);
+  const resolved = path.resolve(resolvedBase, ...parts);
+  const baseWithSep = resolvedBase.endsWith(path.sep) ? resolvedBase : `${resolvedBase}${path.sep}`;
+
+  if (resolved !== resolvedBase && !resolved.startsWith(baseWithSep)) {
+    return null;
+  }
+
+  return resolved;
+}

--- a/tests/server/repositories.test.ts
+++ b/tests/server/repositories.test.ts
@@ -190,6 +190,31 @@ describe('usersRepo', () => {
     const deleted = await usersRepo.delete(user.id);
     expect(deleted).toBe(true);
   });
+
+  it('accepts an invitation only once for a given token', async () => {
+    const token = 'invite-token-once';
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const invited = await usersRepo.createInvited({
+      email: 'invitee@example.com',
+      name: 'Invitee',
+      role: 'editor',
+      invitationToken: token,
+      invitationTokenExpiresAt: expiresAt,
+    });
+
+    const first = await usersRepo.acceptInvitation(invited.id, token, 'hash-one', 'Winner');
+    expect(first?.name).toBe('Winner');
+    expect(first?.isActive).toBe(true);
+
+    const second = await usersRepo.acceptInvitation(invited.id, token, 'hash-two', 'Loser');
+    expect(second).toBeNull();
+
+    const reloaded = await usersRepo.findById(invited.id);
+    expect(reloaded?.name).toBe('Winner');
+
+    const withPassword = await usersRepo.findByEmailWithPassword('invitee@example.com');
+    expect(withPassword?.passwordHash).toBe('hash-one');
+  });
 });
 
 describe('sessionsRepo', () => {

--- a/tests/server/routes/reports.routes.test.ts
+++ b/tests/server/routes/reports.routes.test.ts
@@ -206,6 +206,32 @@ describe('reports routes', () => {
     expect(reportUpdatePayload).toMatchObject({ title: 'New title' });
   });
 
+  it('ignores forwardedTo on report update mass-assignment', async () => {
+    userRole = 'editor';
+    const app = createApp();
+    const res = await app.request('http://localhost/reports/rpt_1', {
+      method: 'PATCH',
+      headers: {
+        cookie: 'session=sess_1',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: 'Still allowed',
+        forwardedTo: [
+          {
+            integrationId: 'int_fake',
+            externalId: '999',
+            externalUrl: 'https://evil.example/issues/999',
+            forwardedAt: '2026-07-09T00:00:00.000Z',
+          },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(reportUpdatePayload).toMatchObject({ title: 'Still allowed' });
+    expect(reportUpdatePayload).not.toHaveProperty('forwardedTo');
+  });
+
   it('blocks delete for non-admin', async () => {
     userRole = 'viewer';
     const app = createApp();

--- a/tests/server/routes/users.routes.test.ts
+++ b/tests/server/routes/users.routes.test.ts
@@ -420,4 +420,17 @@ describe('users routes', () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it('rejects avatar path traversal attempts', async () => {
+    const outside = path.join(config.avatarsDir, 'outside.txt');
+    fs.mkdirSync(config.avatarsDir, { recursive: true });
+    fs.writeFileSync(outside, 'SECRET');
+
+    const app = createApp();
+    const res = await app.request('http://localhost/users/me/avatar/%2e%2e%2foutside.txt', {
+      headers: { cookie: 'session=sess_1' },
+    });
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain('SECRET');
+  });
 });

--- a/tests/server/utils/safe-path.test.ts
+++ b/tests/server/utils/safe-path.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'bun:test';
+import * as path from 'path';
+import { resolvePathInside } from '../../../src/server/utils/safe-path';
+
+describe('resolvePathInside', () => {
+  const base = path.resolve('/tmp/bugpin-avatars');
+
+  it('resolves a simple filename under the base directory', () => {
+    expect(resolvePathInside(base, 'usr_1', 'avatar.png')).toBe(
+      path.resolve(base, 'usr_1', 'avatar.png')
+    );
+  });
+
+  it('rejects encoded-style traversal segments', () => {
+    expect(resolvePathInside(base, 'usr_1', '..')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', '../outside.txt')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', '..\\outside.txt')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', 'a/b.png')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', 'a\\b.png')).toBeNull();
+  });
+
+  it('rejects empty, dot, and NUL segments', () => {
+    expect(resolvePathInside(base, 'usr_1', '')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', '.')).toBeNull();
+    expect(resolvePathInside(base, 'usr_1', 'av\0atar.png')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Three independent server-side security fixes, plus the v1.2.0 changelog entry documenting them. Branch is merged up to date with `dev` (includes the 1.2.0 release line).

- **Avatar path traversal** — `GET /api/users/me/avatar/:filename` now resolves through a new `resolvePathInside` helper that rejects `..`, path separators, and NUL bytes and confirms the resolved path stays under the avatars dir. Confines serving to the requesting user's own directory.
- **Report update mass-assignment** — `PATCH /api/reports/:id` now consumes the validated body instead of the raw JSON payload, and `forwardedTo` is dropped from `UpdateReportInput`/`reportsService.update`. Closes injection of forwarded-integration references.
- **Invitation accept race (TOCTOU)** — `usersRepo.acceptInvitation` consumes the token atomically (`WHERE id = ? AND invitation_token = ? AND invitation_accepted_at IS NULL`), returning null (→ `ALREADY_ACCEPTED`) when it loses the race. Prevents concurrent double-accept / token reuse.

## Why

Path traversal (CWE-22) allowed reading files outside the avatars directory; the raw-body read bypassed the validation schema enabling mass-assignment; and invite acceptance had a check-then-act gap allowing concurrent accepts to both succeed.

## How

- New `src/server/utils/safe-path.ts` (`resolvePathInside`).
- Route/service/repo changes as above; `forwardedTo` removed from the report update path.

## Testing

- New/updated unit + route tests: `safe-path.test.ts`, avatar traversal route test, `forwardedTo` mass-assignment route test, single-use invitation repo test. All pass.
- Full server suite run on the merged tree: no regressions introduced by these changes. (Pre-existing failures on `dev` — 3× `reports routes extras` github-sync tests and 1 rate-limiter test-ordering flake — are unrelated to this PR.)

## Notes

- Merged `origin/dev` into this branch (no conflicts) so it ships alongside 1.2.0.
- Security section added to `Changelog/v1.2.0.md`.