### PR TITLE
fix(security): bump nodemailer to ^9.0.1 to resolve SSRF/file-read advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1047.0",
         "hono": "^4.12.18",
-        "nodemailer": "^8.0.7",
+        "nodemailer": "^9.0.1",
         "sharp": "^0.34.5",
         "zod": "^3.25.76",
       },
@@ -1281,7 +1281,7 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
+    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
 
     "normalize-wheel": ["normalize-wheel@1.0.1", "", {}, "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA=="],
 

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1047.0",
     "hono": "^4.12.18",
-    "nodemailer": "^8.0.7",
+    "nodemailer": "^9.0.1",
     "sharp": "^0.34.5",
     "zod": "^3.25.76"
   },


### PR DESCRIPTION
## What
Bumps `nodemailer` in `src/server` from `^8.0.7` to `^9.0.1` (lockfile resolves to `9.0.3`).

## Why
Resolves Dependabot alert #17 / **GHSA-p6gq-j5cr-w38f** (High): the message-level `raw` option in nodemailer `<9.0.1` bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary local file read and full-response SSRF in the delivered message. The bump also clears three other nodemailer advisories flagged on `<=8.0.8` (CRLF header injection, jsonTransport sandbox bypass, OAuth2 TLS validation).

BugPin's own code is not exploitable today (it never uses the `raw` option or the sandbox flags), but the installed package is genuinely vulnerable, so the fix removes the alert and prevents future reintroduction.

## How
- `bun add nodemailer@^9.0.1` in `src/server` (range from the advisory's patched version; bun resolved `9.0.3`).
- Only `src/server/package.json` and `bun.lock` change. No application code changes.

## Compatibility
The single 9.x breaking change (TLS certificate validation when **fetching remote content** — attachment URLs, OAuth2 token endpoints, HTTP/HTTPS proxy CONNECT) does not affect BugPin, which uses none of those. The SMTP delivery path is unchanged.

## Testing
- `bun run typecheck:server` - clean (before and after)
- Email suite (`email.service`, `email-rendering`, `reporter-email`, `reporter-notifications`, `notifications.service`) - **79 pass / 0 fail** (before and after)
- Full server suite - **735 pass / 4 fail**, identical to baseline; the 4 failures are pre-existing (`dynamicRateLimiter` + 3 github-sync tests) and unrelated to this change
- `bun audit` - total dropped 48 -> 44, **0 nodemailer advisories** remaining

## Notes
- Pre-existing widget typecheck errors (`bun:test` resolution, `vite.config` `rollupTypes`) are unrelated and left untouched.