### PR TITLE
fix(widget): keep dialogs usable on short viewports

### DIFF
--- a/src/widget/annotate/AnnotationCanvas.tsx
+++ b/src/widget/annotate/AnnotationCanvas.tsx
@@ -1030,9 +1030,9 @@ export const AnnotationCanvas: FunctionComponent<AnnotationCanvasProps> = ({
   );
 
   return (
-    <div class="flex flex-col">
+    <div class="h-full min-h-0 flex flex-col">
       {/* Toolbar */}
-      <div class="flex flex-wrap items-center gap-2 px-4 py-3 border-b border-solid border-border bg-muted">
+      <div class="shrink-0 flex flex-wrap items-center gap-2 px-4 py-3 border-b border-solid border-border bg-muted">
         <div class="flex items-center gap-1">
           <ToolButton
             tool="select"
@@ -1162,14 +1162,14 @@ export const AnnotationCanvas: FunctionComponent<AnnotationCanvasProps> = ({
 
       {/* Canvas */}
       <div
-        class="min-h-[600px] min-w-[700px] max-h-[70vh] overflow-auto flex items-center justify-center p-4 bg-muted"
+        class="flex-auto min-h-0 min-w-[700px] overflow-auto flex items-center justify-center p-4 bg-muted"
         ref={canvasWrapperRef}
       >
         <canvas ref={canvasRef} />
       </div>
 
       {/* Actions */}
-      <div class="flex gap-3 p-4 border-t border-solid border-border bg-muted">
+      <div class="shrink-0 flex gap-3 p-4 border-t border-solid border-border bg-muted">
         <Button variant="outline" class="flex-1" onClick={onCancel}>
           {t('annotation.buttons.cancel')}
         </Button>

--- a/src/widget/components/App.tsx
+++ b/src/widget/components/App.tsx
@@ -421,7 +421,7 @@ export const App: FunctionComponent<AppProps> = ({ config, deps }) => {
 
       {step === 'annotating' && annotatingMedia && (
         <div class="fixed inset-0 z-[2147483646] bg-black/50 flex items-center justify-center p-5 animate-[fadeIn_0.2s_ease-out]">
-          <div class="relative max-w-4xl max-h-[90vh] bg-background border border-solid border-border rounded shadow-lg overflow-hidden flex flex-col animate-[slideUp_0.2s_ease-out]">
+          <div class="relative w-full max-w-4xl h-[770px] max-h-[calc(100vh-40px)] min-h-0 bg-background border border-solid border-border rounded shadow-lg overflow-hidden flex flex-col animate-[slideUp_0.2s_ease-out]">
             <AnnotationCanvasComponent
               screenshot={annotatingMedia.dataUrl}
               onSave={handleAnnotationSave}

--- a/src/widget/components/WidgetDialog.tsx
+++ b/src/widget/components/WidgetDialog.tsx
@@ -132,13 +132,13 @@ export const WidgetDialog: FunctionComponent<WidgetDialogProps> = ({
   return (
     <div class="fixed inset-0 z-[2147483646] bg-black/50 flex items-center justify-center p-5 animate-[fadeIn_0.2s_ease-out]">
       <div
-        class="relative w-full max-w-3xl min-h-[770px] max-h-[calc(100vh-40px)] bg-background border border-solid border-border rounded shadow-lg overflow-hidden flex flex-col animate-[slideUp_0.2s_ease-out]"
+        class="relative w-full max-w-3xl h-[770px] max-h-[calc(100vh-40px)] min-h-0 bg-background border border-solid border-border rounded shadow-lg overflow-hidden flex flex-col animate-[slideUp_0.2s_ease-out]"
         role="dialog"
         aria-modal="true"
         aria-labelledby="bugpin-title"
       >
         {/* Header */}
-        <div class="flex items-center justify-between p-6 border-b border-solid border-border">
+        <div class="shrink-0 flex items-center justify-between p-6 border-b border-solid border-border">
           <h1 id="bugpin-title">{t('dialog.title')}</h1>
           <Button variant="ghost" size="icon" onClick={onClose} aria-label={t('aria.close')}>
             <X class="w-5 h-5" />
@@ -150,7 +150,7 @@ export const WidgetDialog: FunctionComponent<WidgetDialogProps> = ({
         ) : (
           <>
             {/* Tabs */}
-            <div class="p-4 pb-0 bg-transparent">
+            <div class="shrink-0 p-4 pb-0 bg-transparent">
               <Tabs tabs={tabs} activeTab={activeTab} onTabChange={onActiveTabChange} />
             </div>
 
@@ -275,7 +275,7 @@ export const WidgetDialog: FunctionComponent<WidgetDialogProps> = ({
             </div>
 
             {/* Footer */}
-            <div class="flex gap-3 p-6 border-t border-solid border-border bg-muted">
+            <div class="shrink-0 flex gap-3 p-6 border-t border-solid border-border bg-muted">
               <Button variant="outline" class="flex-1" onClick={onClose} disabled={isSubmitting}>
                 {t('dialog.buttons.cancel')}
               </Button>
@@ -291,7 +291,7 @@ export const WidgetDialog: FunctionComponent<WidgetDialogProps> = ({
         )}
 
         {/* Branding */}
-        <div class="py-3 px-6 text-center text-xs text-muted-foreground border-t border-solid border-border bg-background">
+        <div class="shrink-0 py-3 px-6 text-center text-xs text-muted-foreground border-t border-solid border-border bg-background">
           {t('dialog.branding.poweredBy')}{' '}
           <a
             href="https://bugpin.io"

--- a/src/widget/tests/components/annotation-canvas.test.tsx
+++ b/src/widget/tests/components/annotation-canvas.test.tsx
@@ -82,6 +82,15 @@ describe('AnnotationCanvas', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10));
 
+    const canvasRegion = container.querySelector('canvas')?.parentElement;
+    const annotationRoot = canvasRegion?.parentElement;
+
+    expect(annotationRoot?.classList.contains('h-full')).toBe(true);
+    expect(annotationRoot?.classList.contains('min-h-0')).toBe(true);
+    expect(canvasRegion?.classList.contains('flex-auto')).toBe(true);
+    expect(canvasRegion?.classList.contains('min-h-0')).toBe(true);
+    expect(canvasRegion?.classList.contains('min-h-[600px]')).toBe(false);
+
     const buttons = Array.from(container.querySelectorAll('button'));
     const cancelButton = buttons.find((btn) => btn.textContent?.trim() === 'Cancel');
     const doneButton = buttons.find((btn) => btn.textContent?.trim() === 'Done');

--- a/src/widget/tests/components/app-interactions.test.tsx
+++ b/src/widget/tests/components/app-interactions.test.tsx
@@ -267,6 +267,13 @@ describe('App interactions', () => {
       'Fabric canvas not ready'
     );
 
+    const annotationRoot = container.querySelector('canvas')?.parentElement?.parentElement;
+    const annotationModal = annotationRoot?.parentElement;
+
+    expect(annotationModal?.classList.contains('h-[770px]')).toBe(true);
+    expect(annotationModal?.classList.contains('max-h-[calc(100vh-40px)]')).toBe(true);
+    expect(annotationModal?.classList.contains('min-h-0')).toBe(true);
+
     const doneButton = await waitFor(
       () =>
         Array.from(container.querySelectorAll('button')).find(

--- a/src/widget/tests/components/widget-components.test.tsx
+++ b/src/widget/tests/components/widget-components.test.tsx
@@ -232,6 +232,9 @@ describe('widget components', () => {
     );
     expect(html).toContain('Report a Bug');
     expect(html).toContain('Submit Report');
+    expect(html).toContain('h-[770px]');
+    expect(html).not.toContain('min-h-[770px]');
+    expect(html).toContain('max-h-[calc(100vh-40px)]');
   });
 
   it('renders widget dialog media tab with count', () => {


### PR DESCRIPTION
## Summary
- bound report and annotation dialogs to the available viewport height
- keep modal controls visible while form content and annotation canvases scroll internally
- add regression coverage for the responsive layout contracts

Closes #62

## Test plan
- [x] Focused report dialog component test
- [x] Annotation canvas component tests
- [x] Focused annotation integration test
- [x] Production widget build
- [x] Browser verification at 1024x600, 1366x730, and 1440x900
- [x] Gzipped IIFE remains below 175 KiB (152,669 bytes)

## Known baseline issues
- The full widget suite has pre-existing shared-global teardown failures involving `cancelAnimationFrame`.
- Widget type checking has pre-existing unresolved `bun:test` types and a `rollupTypes` plugin option error.